### PR TITLE
Abolish redundant schema type definiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,10 @@ do {
 # Create
 ```swift
 let create = Create(table: "users", fields: [
-    Schema.Field(name: "id", type: Schema.Types.Integer()).asPrimaryKey().asAutoIncrement(),
-    Schema.Field(name: "name", type: Schema.Types.String()),
-    Schema.Field(name: "email", type: Schema.Types.String()).asUnique(),
-    Schema.Field(name: "last_logined_at", type: Schema.Types.DateTime()).asIndex()
+    Schema.integer("id").asPrimaryKey().asAutoIncrement(),
+    Schema.string("name"),
+    Schema.string("email").asUnique(),
+    Schema.datetime("last_logined_at").asIndex()
 ])
 .hasTimeStamps() // add created_at and updated_at
 
@@ -262,18 +262,18 @@ try knex().execRaw(sql: create.toDDL())
 
 ### Schema Types Comparison
 
-| Schema.Types  | Mysql Type    |
-| ------------- |:-------------:|
-| String       | VARCHAR        |
-| Integer      | INT            |
-| BigInteger   | BIGIMT         |
-| DateTime     | DATETIME       |
-| Text         | TEXT           |
-| MediumText   | MEDIUMTEXT     |
-| Float        | FLOAT          |
-| Double       | DOUBLE         |
-| Boolean      | TINYINT(1)     |
-| JSON         | JSON           |
+| SwiftKnex           |  Mysql Type    |
+| ------------------- |:--------------:|
+| Schema.string       | VARCHAR        |
+| Schema.integer      | INT            |
+| Schema.bigInteger   | BIGIMT         |
+| Schema.dateTime     | DATETIME       |
+| Schema.text         | TEXT           |
+| Schema.mediumText   | MEDIUMTEXT     |
+| Schema.float        | FLOAT          |
+| Schema.double       | DOUBLE         |
+| Schema.boolean      | TINYINT(1)     |
+| Schema.json         | JSON           |
 
 ### Functions for adding field attributes
 * `default(as value: Any)`
@@ -362,9 +362,9 @@ class Migration_20170116015823_CreateUser: Migratable {
        let create = Create(
            table: "users",
            fields: [
-               Schema.Field(name: "id", type: Schema.Types.Integer()).asPrimaryKey().asAutoIncrement(),
-               Schema.Field(name: "name", type: Schema.Types.String()).asIndex().asNotNullable(),
-               Schema.Field(name: "email", type: Schema.Types.String()).asUnique().asNotNullable()
+               Schema.integer("id").asPrimaryKey().asAutoIncrement(),
+               Schema.string("name").asIndex().asNotNullable(),
+               Schema.string("email").asUnique().asNotNullable()
            ])
            .hasTimestamps()
            .index(columns: ["name", "email"], unique: true)

--- a/Sources/SwiftKnex/Migration/Migrator.swift
+++ b/Sources/SwiftKnex/Migration/Migrator.swift
@@ -228,10 +228,10 @@ class MigrateRunner {
         }
         
         let createDDL = Create(table: con.config.migration.table, fields: [
-            Schema.Field(name: "id", type: Schema.Types.Integer()).asPrimaryKey().asAutoIncrement(),
-            Schema.Field(name: "name", type: Schema.Types.String()),
-            Schema.Field(name: "batch", type: Schema.Types.Integer()),
-            Schema.Field(name: "migration_time", type: Schema.Types.DateTime()).asNotNullable()
+            Schema.integer("id").asPrimaryKey().asAutoIncrement(),
+            Schema.string("name"),
+            Schema.integer("batch"),
+            Schema.datetime("migration_time")
         ])
         
         _ = try con.knex().execRaw(sql: createDDL.toDDL())

--- a/Sources/SwiftKnex/QueryBuilder/UpdateQueryBuilder.swift
+++ b/Sources/SwiftKnex/QueryBuilder/UpdateQueryBuilder.swift
@@ -65,12 +65,6 @@ struct UpdateQueryBuilder: QueryBuildable {
         sql += insertSpace(orders.build())
         sql += insertSpace(limitQuery)
         
-        print("----------------------------------")
-//        
-//        bindParams.map({
-//            
-//        })
-        
         print(bindParams)
         
         return (sql, bindParams)

--- a/Templates/Migration-Class.swift.stab
+++ b/Templates/Migration-Class.swift.stab
@@ -7,23 +7,18 @@ class Migration_${migrationFileName}: Migratable {
     }
 
     func up(_ migrator: Migrator) throws {
-
-//        let create = Create(
+//        let tests = Create(
 //            table: "tests",
 //            fields: [
-//                Schema.Field(name: "id", type: Schema.Types.Integer()).asPrimaryKey().asAutoIncrement(),
-//                Schema.Field(name: "name", type: Schema.Types.String()).asIndex().asNotNullable(),
+//                Schema.integer("id").asPrimaryKey().asAutoIncrement(),
+//                Schema.string("name").asIndex().asNotNullable(),
 //            ])
 //            .hasTimestamps()
-//            .index(columns: ["name", "email"], unique: true)
 //
-//        try migrator.run(create)
-
+//        try migrator.run(tests)
     }
 
     func down(_ migrator: Migrator) throws {
-
 //        try migrator.run(Drop(table: "tests"))
-
     }
 }

--- a/Tests/SwiftKnexTests/DDLTests.swift
+++ b/Tests/SwiftKnexTests/DDLTests.swift
@@ -42,19 +42,20 @@ class DDLTests: XCTestCase {
     
     func testCreate(){
         let create = Create(table: "test_users", fields: [
-            Schema.Field(name: "id", type: Schema.Types.Integer()).asPrimaryKey().asAutoIncrement(),
-            Schema.Field(name: "f1", type: Schema.Types.String()).asUnique().asNotNullable(),
-            Schema.Field(name: "f2", type: Schema.Types.Text()),
-            Schema.Field(name: "f3", type: Schema.Types.MediumText()),
-            Schema.Field(name: "f4", type: Schema.Types.BigInteger()).asUnsigned().default(to: 0),
-            Schema.Field(name: "f5", type: Schema.Types.DateTime()).asIndex(),
-            Schema.Field(name: "f6", type: Schema.Types.Float()),
-            Schema.Field(name: "f7", type: Schema.Types.Double()),
-            Schema.Field(name: "f8", type: Schema.Types.Boolean()).asIndex()
+            Schema.integer("id").asPrimaryKey().asAutoIncrement(),
+            Schema.string("f1").asUnique().asNotNullable(),
+            Schema.text("f2"),
+            Schema.mediumText("f3"),
+            Schema.bigInteger("f4").asUnsigned().default(to: 0),
+            Schema.datetime("f5"),
+            Schema.float("f6"),
+            Schema.double("f7"),
+            Schema.boolean("f8").asIndex(),
+            Schema.json("f9")
         ])
         .hasTimestamps()
         
-        try! con.knex().execRaw(sql: create.toDDL())
+        _ = try! con.knex().execRaw(sql: create.toDDL())
     }
 }
 

--- a/Tests/SwiftKnexTests/JSONDataTypeTests.swift
+++ b/Tests/SwiftKnexTests/JSONDataTypeTests.swift
@@ -26,8 +26,8 @@ class JSONDataTypeTests: XCTestCase {
         dropTable()
         
         let jsonTable = Create(table: "json_table", fields: [
-            Schema.Field(name: "id", type: Schema.Types.Integer()).asPrimaryKey().asAutoIncrement(),
-            Schema.Field(name: "body", type: Schema.Types.JSON())
+            Schema.integer("id").asPrimaryKey().asAutoIncrement(),
+            Schema.json("body")
         ])
         
         try! con.knex().transaction { trx in

--- a/Tests/SwiftKnexTests/MigrationTests.swift
+++ b/Tests/SwiftKnexTests/MigrationTests.swift
@@ -19,9 +19,9 @@ class Migration_20170101000000_CreateEmployee: Migratable {
         let create = Create(
             table: "employees",
             fields: [
-                Schema.Field(name: "id", type: Schema.Types.Integer()).asPrimaryKey().asAutoIncrement(),
-                Schema.Field(name: "name", type: Schema.Types.String()).asIndex().asNotNullable(),
-                Schema.Field(name: "company_id", type: Schema.Types.Integer()).asIndex().asNotNullable()
+                Schema.integer("id").asPrimaryKey().asAutoIncrement(),
+                Schema.string("name").asIndex().asNotNullable(),
+                Schema.integer("company_id").asIndex().asNotNullable()
             ])
             .hasTimestamps()
 
@@ -42,8 +42,8 @@ class Migration_20170102000000_CreateCompany: Migratable {
         let create = Create(
             table: "companies",
             fields: [
-                Schema.Field(name: "id", type: Schema.Types.Integer()).asPrimaryKey().asAutoIncrement(),
-                Schema.Field(name: "name", type: Schema.Types.String()).asNotNullable()
+                Schema.integer("id").asPrimaryKey().asAutoIncrement(),
+                Schema.string("name").asNotNullable()
             ])
             .hasTimestamps()
         

--- a/Tests/SwiftKnexTests/Util.swift
+++ b/Tests/SwiftKnexTests/Util.swift
@@ -68,9 +68,9 @@ func basicKnexConfig() -> KnexConfig {
 
 func testUserLastLoginSchema() -> Create {
     return Create(table: "test_user_last_logins", fields: [
-        Schema.Field(name: "id", type: Schema.Types.Integer()).asPrimaryKey().asAutoIncrement(),
-        Schema.Field(name: "user_id", type: Schema.Types.Integer()).asUnique(),
-        Schema.Field(name: "last_logined_at", type: Schema.Types.DateTime()).asIndex()
+        Schema.integer("id").asPrimaryKey().asAutoIncrement(),
+        Schema.integer("user_id").asUnique(),
+        Schema.datetime("last_logined_at").asIndex()
     ])
 }
 
@@ -93,11 +93,11 @@ func testUserLastLoginCollection() -> [[String: Any]] {
 
 func testUserSchema() -> Create {
     return Create(table: "test_users", fields: [
-        Schema.Field(name: "id", type: Schema.Types.Integer()).asPrimaryKey().asAutoIncrement(),
-        Schema.Field(name: "email", type: Schema.Types.String()).asUnique(),
-        Schema.Field(name: "name", type: Schema.Types.String()).asNotNullable(),
-        Schema.Field(name: "age", type: Schema.Types.Integer()).asNotNullable(),
-        Schema.Field(name: "Country", type: Schema.Types.String()),
+        Schema.integer("id").asPrimaryKey().asAutoIncrement(),
+        Schema.string("email").asUnique(),
+        Schema.string("name").asNotNullable(),
+        Schema.integer("age").asNotNullable(),
+        Schema.string("Country")
     ])
 }
 


### PR DESCRIPTION
* Remove Schema.Field.FooType()
* Add Schema.fooType() methods instead of them

new syntax is...
``` swift
Create(table: con.config.migration.table, fields: [
    Schema.integer("id").asPrimaryKey().asAutoIncrement(),
    Schema.string("name"),
    Schema.integer("batch"),
    Schema.datetime("migration_time")
])
```